### PR TITLE
Fixed 'take a peek' functionality

### DIFF
--- a/index.php
+++ b/index.php
@@ -321,9 +321,11 @@ function code_peek() {
 <?php
 
 	$field_list = $rets->SearchGetFields($search);
-
+	$rets->FreeResult($search);
+	
 	$system_to_long = array();
 	$table_metadata = $rets->GetMetadataTable($_REQUEST['r_resource'], $_REQUEST['r_class']);
+	
 	foreach ($table_metadata as $fi) {
 		$system_to_long["{$fi['SystemName']}"] = $fi['LongName'];
 	}

--- a/phrets.php
+++ b/phrets.php
@@ -476,9 +476,6 @@ class phRETS {
 					$this_row[$name] = $field_data[$key];
 				}
 			}
-			else {
-				$this->FreeResult($pointer_id);
-			}
 		}
 
 		return $this_row;


### PR DESCRIPTION
Quick and dirty fix for the not working "take a peek" function. I'm sure there are other (read: better) ways to handle this without running a custom version of PHRETS, but this will correct the problem for the time being until someone can slot out some time for a better long term solution.
